### PR TITLE
feat: separate date and time pickers for plan and reminder times

### DIFF
--- a/screens/plan/ModifyPlanScreen.js
+++ b/screens/plan/ModifyPlanScreen.js
@@ -1,22 +1,29 @@
-import { StyleSheet, Text, View, TextInput, FlatList, TouchableOpacity, Alert} from 'react-native'
-import React, {useState, useRef} from 'react'
+import { StyleSheet, Text, View, TextInput, FlatList, TouchableOpacity, Alert, Button } from 'react-native';
+import React, { useState, useRef } from 'react';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { SearchBar } from '@rneui/themed';
 import { fetchData, getItemById } from '../../services/dataService';
-import PressableButton from '../../components/common/PressableButton';
 import { writeToDB, updateDB } from '../../firebase/firestoreHelper';
+import Screen from '../../components/common/Screen';
+import PressableButton from '../../components/common/PressableButton';
+import commonStyles from '../../utils/style';
 
-export default function ModifyPlanScreen( {navigation, route} ) {
+export default function ModifyPlanScreen({ navigation, route }) {
   const { item } = route.params;
   const isModify = item ? true : false;
   const playgrounds = fetchData();
 
   const [planName, setPlanName] = useState(isModify ? item.planName : '');
   const [selectedPlayground, setSelectedPlayground] = useState(checkPlayground(item));
-  const [time, setTime] = useState( isModify && item.time? item.time.toDate() : new Date());
-  const [reminderTime, setReminderTime] = useState(isModify && item.reminderTime ? item.reminderTime.toDate() : new Date())
+  const [time, setTime] = useState(isModify && item.time ? item.time.toDate() : new Date());
+  const [reminderTime, setReminderTime] = useState(isModify && item.reminderTime ? item.reminderTime.toDate() : new Date());
   const [searchQuery, setSearchQuery] = useState('');
   const [filteredPlaygrounds, setFilteredPlaygrounds] = useState(playgrounds);
+
+  const [showDatePicker, setShowDatePicker] = useState(false);
+  const [showTimePicker, setShowTimePicker] = useState(false);
+  const [showReminderDatePicker, setShowReminderDatePicker] = useState(false);
+  const [showReminderTimePicker, setShowReminderTimePicker] = useState(false);
 
   const searchBarRef = useRef(null);
 
@@ -27,8 +34,8 @@ export default function ModifyPlanScreen( {navigation, route} ) {
     } else {
       return '';
     }
-  };
-  
+  }
+
   const handleSearch = (query) => {
     setSearchQuery(query);
     setFilteredPlaygrounds(
@@ -51,7 +58,7 @@ export default function ModifyPlanScreen( {navigation, route} ) {
       planName: planName,
       playgroundId: selectedPlayground.id,
       time: time,
-      reminderTime:reminderTime,
+      reminderTime: reminderTime,
       archived: false,
     };
 
@@ -63,13 +70,13 @@ export default function ModifyPlanScreen( {navigation, route} ) {
       // Updating the existing entry in the data
       updateDB(item.id, newPlanData, 'plan');
     }
-    // Navigating back to the previous screen
-    navigation.navigate('Main', {screen: 'Plan'});
+    navigation.navigate('Main', { screen: 'Plan' });
   };
 
   return (
+    <Screen>
     <View style={styles.container}>
-      <Text>Select Location</Text>
+      <Text style={commonStyles.header}>Location: </Text>
       <SearchBar
         placeholder="Search Playground"
         onChangeText={handleSearch}
@@ -81,51 +88,121 @@ export default function ModifyPlanScreen( {navigation, route} ) {
         inputStyle={styles.searchInput}
       />
       {searchQuery && !selectedPlayground && (
-      <FlatList
-        data={filteredPlaygrounds}
-        keyExtractor={(item) => item.id}
-        renderItem={({ item }) => (
-          <TouchableOpacity onPress={() => {
-            setSelectedPlayground(item);
-            setSearchQuery(''); // Clear search query
-            searchBarRef.current.blur();; // Clear search bar
-            }}>
-            <Text style={styles.playgroundItem}>{item.name}</Text>
-          </TouchableOpacity>
-        )}
-      />
+        <FlatList
+          data={filteredPlaygrounds}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => (
+            <TouchableOpacity
+              onPress={() => {
+                setSelectedPlayground(item);
+                setSearchQuery('');
+                searchBarRef.current.blur();
+              }}>
+              <Text style={styles.playgroundItem}>{item.name}</Text>
+            </TouchableOpacity>
+          )}
+        />
       )}
-      {selectedPlayground && <Text>Selected Playground: {selectedPlayground.name}</Text>}
-      <Text>Plan Name:</Text>
+      {selectedPlayground && <Text style={commonStyles.planName}>Selected: {selectedPlayground.name}</Text>}
+      <Text style={commonStyles.header}>Plan Name:</Text>
       <TextInput
         placeholder="Plan Name"
         value={planName}
         onChangeText={setPlanName}
         style={styles.input}
       />
-      <Text>Select Time:</Text>
-      <DateTimePicker
-        value={time}
-        mode="datetime"
-        display="default"
-        onChange={(event, selectedDate) => setTime(selectedDate || time)}
-      />
-      <Text>Select Reminder Time:</Text>
-      <DateTimePicker
-        value={reminderTime}
-        mode="datetime"
-        display="default"
-        onChange={(event, selectedDate) => setReminderTime(selectedDate || reminderTime)}
-      />
+
+      {/* Date and Time Pickers for Plan Time */}
+      <Text style={commonStyles.header}>Time:</Text>
+      <View style={commonStyles.buttonContainer}>
+        <PressableButton 
+          pressHandler={() => setShowDatePicker(true)}
+          componentStyle={commonStyles.timeButton}>
+          <Text>{time.toLocaleDateString()}</Text>
+        </PressableButton>
+        <PressableButton
+          pressHandler={() => setShowTimePicker(true)}
+          componentStyle={commonStyles.timeButton}>
+          <Text>{time.toLocaleTimeString()}</Text>
+        </PressableButton>
+      </View>
+      <View style={commonStyles.buttonContainer}>
+      {showDatePicker && (
+        <DateTimePicker
+          value={time}
+          mode="date"
+          display="default"
+          onChange={(event, selectedDate) => {
+            setShowDatePicker(false);
+            if (selectedDate) setTime(selectedDate);
+          }}
+        />
+      )}
+      {showTimePicker && (
+        <DateTimePicker
+          value={time}
+          mode="time"
+          display="default"
+          onChange={(event, selectedTime) => {
+            setShowTimePicker(false);
+            if (selectedTime) setTime(new Date(time.setHours(selectedTime.getHours(), selectedTime.getMinutes())));
+          }}
+        />
+      )}
+      </View>
+      {/* Date and Time Pickers for Reminder Time */}
+      <Text style={commonStyles.header}>Reminder Time:</Text>
+      <View style={commonStyles.buttonContainer}>
+        <PressableButton
+          pressHandler={() => setShowReminderDatePicker(true)}
+          componentStyle={commonStyles.timeButton}>
+          <Text>{reminderTime.toLocaleDateString()}</Text>
+        </PressableButton>
+        <PressableButton
+          pressHandler={() => setShowReminderTimePicker(true)}
+          componentStyle={commonStyles.timeButton}>
+          <Text>{reminderTime.toLocaleTimeString()}</Text>
+        </PressableButton>
+      </View>
+      <View style={commonStyles.buttonContainer}>
+      {showReminderDatePicker && (
+        <DateTimePicker
+          value={reminderTime}
+          mode="date"
+          display="default"
+          onChange={(event, selectedDate) => {
+            setShowReminderDatePicker(false);
+            if (selectedDate) setReminderTime(selectedDate);
+          }}
+        />
+      )}
+      {showReminderTimePicker && (
+        <DateTimePicker
+          value={reminderTime}
+          mode="time"
+          display="default"
+          onChange={(event, selectedTime) => {
+            setShowReminderTimePicker(false);
+            if (selectedTime) setReminderTime(new Date(reminderTime.setHours(selectedTime.getHours(), selectedTime.getMinutes())));
+          }}
+        />
+      )}
+      </View>
+
       <View style={styles.buttonContainer}>
-      <PressableButton pressHandler={() => navigation.goBack()}>
-        <Text>Cancel</Text>
-      </PressableButton>
-      <PressableButton pressHandler={handleSave}>
-        <Text>Submit</Text>
-      </PressableButton>
+        <PressableButton
+          pressHandler={() => navigation.goBack()}
+          componentStyle={commonStyles.editButton}>
+          <Text>Cancel</Text>
+        </PressableButton>
+        <PressableButton
+          pressHandler={handleSave}
+          componentStyle={commonStyles.editButton}>
+          <Text>Submit</Text>
+        </PressableButton>
       </View>
     </View>
+    </Screen>
   );
 }
 

--- a/utils/style.js
+++ b/utils/style.js
@@ -43,6 +43,14 @@ const commonStyles = {
     backgroundColor: "#74e0aa",
     borderRadius: 5,
   },
+  timeButton: {
+    padding: 10,
+    margin: 10,
+    backgroundColor: "#f2e5db",
+    borderColor: "#f37e43",
+    borderWidth: 2,
+    borderRadius: 10,
+  },
   alertButton: {
     padding: 10,
     margin: 10,


### PR DESCRIPTION
- Split `DateTimePicker` into separate date and time pickers for both `time` and `reminderTime` due to Android limitations with 'datetime' mode
- Added state management for showing/hiding individual date and time pickers
- Updated `handleSave` logic to store combined date and time as a single timestamp
- Improved user experience by allowing more precise control over date and time selection
- Refactored components and updated UI elements for better usability